### PR TITLE
HouseWorkCardにラベル表示機能を追加 #16

### DIFF
--- a/src/components/organisms/HouseWorkCard.tsx
+++ b/src/components/organisms/HouseWorkCard.tsx
@@ -8,6 +8,7 @@ import {
   CardActionArea,
   CardContent,
   CardProps,
+  Chip,
   Divider,
   Stack,
   Typography,
@@ -18,20 +19,70 @@ export type HouseWorkCardProps = CardProps & {
   onClick?: () => void
 }
 
+/**
+ * ラベル表示ロジック
+ * - 未承認の場合: 「未承認」ラベル
+ * - 承認済みの場合:
+ *   - 作成日時が1週間以内: 「New」ラベル
+ *   - 作成日時が1週間以内でなく、更新日時が1週間以内: 「Update」ラベル
+ */
+const getLabel = (housework: Housework): string | null => {
+  // 未承認チェック
+  if (!housework.committed) {
+    return '未承認'
+  }
+
+  const now = new Date()
+  const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+  const createdAt = new Date(housework.createdAt)
+  const updatedAt = new Date(housework.updatedAt)
+
+  // 作成日時が1週間以内
+  if (createdAt > oneWeekAgo) {
+    return 'New'
+  }
+
+  // 更新日時が1週間以内
+  if (updatedAt > oneWeekAgo) {
+    return 'Update'
+  }
+
+  return null
+}
+
 export const HouseWorkCard = (props: HouseWorkCardProps) => {
   const { housework, onClick, ...remainProps } = props
+  const label = getLabel(housework)
 
   return (
     <Card
       sx={{
         width: '250px',
         boxShadow: '0px 4px 4px 0px rgb(0 0 0 / 20%)',
+        position: 'relative',
       }}
       {...remainProps}
     >
       <CardActionArea onClick={onClick}>
         <CardContent>
-          <Stack spacing={1}>
+          <Stack mt={-1} spacing={1}>
+            <Box height={24}>
+              {label && (
+                <Chip
+                  label={label}
+                  size='small'
+                  sx={{
+                    backgroundColor:
+                      label === '未承認'
+                        ? '#D1D1D1'
+                        : label === 'New'
+                          ? '#64B5F6'
+                          : '#81C784',
+                    color: '#FFFFFF',
+                  }}
+                />
+              )}
+            </Box>
             <Stack width='100%' alignItems='center'>
               <HouseWorkImage
                 category={housework.category}


### PR DESCRIPTION
## Summary

HouseWorkCardコンポーネントに、カードの先頭にラベルを表示する機能を追加しました。

- 未承認の家事には「未承認」ラベルを表示（グレー）
- 作成日時が1週間以内の承認済み家事には「New」ラベルを表示（青）
- 更新日時が1週間以内の承認済み家事には「Update」ラベルを表示（緑）

## 実装内容

### ラベル表示ロジック (`getLabel` 関数)
- `committed === false` の場合: 「未承認」を返す
- `committed === true` かつ作成日時が1週間以内: 「New」を返す
- `committed === true` かつ更新日時が1週間以内（作成日時は1週間以内でない）: 「Update」を返す
- 上記に該当しない場合: `null` を返す

### UI実装
- MUIの `Chip` コンポーネントを使用
- カードコンテンツの先頭に24pxの高さで配置
- ラベルごとに色を設定:
  - 未承認: `#D1D1D1` (グレー)
  - New: `#64B5F6` (青)
  - Update: `#81C784` (緑)

## Test plan

- [x] 未承認の家事カードに「未承認」ラベルが表示されることを確認
- [x] 作成から1週間以内の承認済み家事カードに「New」ラベルが表示されることを確認
- [x] 作成から1週間以上経過し、更新から1週間以内の承認済み家事カードに「Update」ラベルが表示されることを確認
- [x] 作成・更新ともに1週間以上経過した承認済み家事カードにラベルが表示されないことを確認
- [x] レスポンシブデザインでレイアウトが崩れないことを確認

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)