### PR TITLE
家事一覧で無限スクロール機能を実装 (Issue #14)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,8 +14,7 @@
       "Bash(yarn add zustand)",
       "Bash(find:*)",
       "Bash(yarn format:check)",
-      "mcp__mui-mcp__useMuiDocs",
-      "Bash(git commit -m \"$(cat <<''EOF''\n無限スクロール: バグ修正とデバッグログ追加\n\n## 修正内容\n\n### 問題\n- 11件以上のデータがある場合、11件目以降が表示できない\n- スクロールしても loadMoreHouseWorks が実行されていない\n\n### 原因\n1. useCallback の依存配列に isLoadingMore が含まれていた\n   - ページ読み込み中に isLoadingMore が true → false に変わると、新しい loadMoreHouseWorks 関数が生成される\n   - これによって handleLoadMore も再生成され、Intersection Observer が無効化される\n\n2. Intersection Observer の threshold 設定がなかった\n   - デフォルトでは要素が完全にビューポート内に入る必要があり、センチネル要素が検出されない可能性がある\n\n### 修正\n1. useHouseWorks.ts の loadMoreHouseWorks useCallback から isLoadingMore を依存配列から削除\n2. HouseWorksTemplate.tsx で Intersection Observer に threshold: 0.1 を指定\n3. useMemo でオプションオブジェクトを保持して参照の安定性を確保\n4. デバッグログを追加して問題の原因特定が容易に\n\n## ログ出力\n- [useIntersectionObserver] - observer の発動状況\n- [handleLoadMore] - ハンドラの実行状況\n- [getHouseWorksList] - 初期データ取得の状況\n- [loadMoreHouseWorks] - 追加データ取得の詳細\n\nこれらのログでブラウザコンソールから無限スクロール動作を追跡できます\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
+      "mcp__mui-mcp__useMuiDocs"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,8 @@
       "Bash(yarn add zustand)",
       "Bash(find:*)",
       "Bash(yarn format:check)",
-      "mcp__mui-mcp__useMuiDocs"
+      "mcp__mui-mcp__useMuiDocs",
+      "Bash(git commit -m \"$(cat <<''EOF''\n無限スクロール: バグ修正とデバッグログ追加\n\n## 修正内容\n\n### 問題\n- 11件以上のデータがある場合、11件目以降が表示できない\n- スクロールしても loadMoreHouseWorks が実行されていない\n\n### 原因\n1. useCallback の依存配列に isLoadingMore が含まれていた\n   - ページ読み込み中に isLoadingMore が true → false に変わると、新しい loadMoreHouseWorks 関数が生成される\n   - これによって handleLoadMore も再生成され、Intersection Observer が無効化される\n\n2. Intersection Observer の threshold 設定がなかった\n   - デフォルトでは要素が完全にビューポート内に入る必要があり、センチネル要素が検出されない可能性がある\n\n### 修正\n1. useHouseWorks.ts の loadMoreHouseWorks useCallback から isLoadingMore を依存配列から削除\n2. HouseWorksTemplate.tsx で Intersection Observer に threshold: 0.1 を指定\n3. useMemo でオプションオブジェクトを保持して参照の安定性を確保\n4. デバッグログを追加して問題の原因特定が容易に\n\n## ログ出力\n- [useIntersectionObserver] - observer の発動状況\n- [handleLoadMore] - ハンドラの実行状況\n- [getHouseWorksList] - 初期データ取得の状況\n- [loadMoreHouseWorks] - 追加データ取得の詳細\n\nこれらのログでブラウザコンソールから無限スクロール動作を追跡できます\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nEOF\n)\")"
     ],
     "deny": [],
     "ask": []

--- a/src/components/templates/HouseWorksTemplate.tsx
+++ b/src/components/templates/HouseWorksTemplate.tsx
@@ -21,7 +21,7 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 export function HouseWorksTemplate() {
   const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser()
@@ -45,9 +45,25 @@ export function HouseWorksTemplate() {
 
   // 無限スクロール時に次ページを読み込む
   const handleLoadMore = useCallback(() => {
+    // デバッグ: 何度呼ばれているか確認
+    console.log(
+      '[handleLoadMore] Intersection detected - hasNextPage:',
+      hasNextPage,
+      'isLoadingMore:',
+      isLoadingMore,
+      'isHouseWorksLoading:',
+      isHouseWorksLoading,
+    )
+
     if (currentUser && hasNextPage && !isLoadingMore && !isHouseWorksLoading) {
+      console.log(
+        '[handleLoadMore] Loading more items... Current total:',
+        houseWorksList?.edges?.length,
+      )
       const sortParams = getSortParams(sortType)
       loadMoreHouseWorks(currentUser.family_id, sortParams, filter)
+    } else {
+      console.log('[handleLoadMore] Conditions not met')
     }
   }, [
     currentUser,
@@ -57,10 +73,23 @@ export function HouseWorksTemplate() {
     sortType,
     filter,
     loadMoreHouseWorks,
+    houseWorksList?.edges?.length,
   ])
 
+  // Intersection Observer のオプションを useMemo で保持
+  // 毎回同じオブジェクト参照を使用することで observer の再生成を防ぐ
+  const intersectionOptions = useMemo(
+    () => ({
+      threshold: 0.1,
+    }),
+    [],
+  )
+
   // センチネル要素の ref（画面下部に配置してスクロール検出）
-  const sentinelRef = useIntersectionObserver(handleLoadMore)
+  const sentinelRef = useIntersectionObserver(
+    handleLoadMore,
+    intersectionOptions,
+  )
 
   // Map sort type to GraphQL sort parameters
   const getSortParams = (sortType: string) => {

--- a/src/components/templates/HouseWorksTemplate.tsx
+++ b/src/components/templates/HouseWorksTemplate.tsx
@@ -45,25 +45,9 @@ export function HouseWorksTemplate() {
 
   // 無限スクロール時に次ページを読み込む
   const handleLoadMore = useCallback(() => {
-    // デバッグ: 何度呼ばれているか確認
-    console.log(
-      '[handleLoadMore] Intersection detected - hasNextPage:',
-      hasNextPage,
-      'isLoadingMore:',
-      isLoadingMore,
-      'isHouseWorksLoading:',
-      isHouseWorksLoading,
-    )
-
     if (currentUser && hasNextPage && !isLoadingMore && !isHouseWorksLoading) {
-      console.log(
-        '[handleLoadMore] Loading more items... Current total:',
-        houseWorksList?.edges?.length,
-      )
       const sortParams = getSortParams(sortType)
       loadMoreHouseWorks(currentUser.family_id, sortParams, filter)
-    } else {
-      console.log('[handleLoadMore] Conditions not met')
     }
   }, [
     currentUser,
@@ -73,7 +57,6 @@ export function HouseWorksTemplate() {
     sortType,
     filter,
     loadMoreHouseWorks,
-    houseWorksList?.edges?.length,
   ])
 
   // Intersection Observer のオプションを useMemo で保持

--- a/src/components/templates/HouseWorksTemplate.tsx
+++ b/src/components/templates/HouseWorksTemplate.tsx
@@ -111,7 +111,7 @@ export function HouseWorksTemplate() {
     // Reload houseworks list after successful create/update
     if (currentUser) {
       const sortParams = getSortParams(sortType)
-      getHouseWorksList(currentUser.family_id, sortParams, filter)
+      getHouseWorksList(currentUser.family_id, sortParams, filter, true)
     }
   }
 

--- a/src/components/templates/HouseWorksTemplate.tsx
+++ b/src/components/templates/HouseWorksTemplate.tsx
@@ -6,7 +6,11 @@ import {
   HouseWorkSearch,
 } from '@/components/organisms'
 import { Housework, HouseworkFilterInput } from '@/graphql/generated/components'
-import { useCurrentUser, useLocalStorage } from '@/hooks'
+import {
+  useCurrentUser,
+  useIntersectionObserver,
+  useLocalStorage,
+} from '@/hooks'
 import { useHouseWorks } from '@/hooks/api/useHouseWorks'
 import {
   CircularProgress,
@@ -17,14 +21,17 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 export function HouseWorksTemplate() {
   const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser()
   const {
     isLoading: isHouseWorksLoading,
+    isLoadingMore,
     getHouseWorksList,
+    loadMoreHouseWorks,
     houseWorksList,
+    hasNextPage,
   } = useHouseWorks()
   const [sortType, setSortType] = useLocalStorage<string>(
     'housework-sort-type',
@@ -35,6 +42,25 @@ export function HouseWorksTemplate() {
   const [selectedHousework, setSelectedHousework] = useState<Housework | null>(
     null,
   )
+
+  // 無限スクロール時に次ページを読み込む
+  const handleLoadMore = useCallback(() => {
+    if (currentUser && hasNextPage && !isLoadingMore && !isHouseWorksLoading) {
+      const sortParams = getSortParams(sortType)
+      loadMoreHouseWorks(currentUser.family_id, sortParams, filter)
+    }
+  }, [
+    currentUser,
+    hasNextPage,
+    isLoadingMore,
+    isHouseWorksLoading,
+    sortType,
+    filter,
+    loadMoreHouseWorks,
+  ])
+
+  // センチネル要素の ref（画面下部に配置してスクロール検出）
+  const sentinelRef = useIntersectionObserver(handleLoadMore)
 
   // Map sort type to GraphQL sort parameters
   const getSortParams = (sortType: string) => {
@@ -137,7 +163,7 @@ export function HouseWorksTemplate() {
           </FormControl>
         </Stack>
       </Stack>
-      {/* TODO: 家事一覧の実装 */}
+      {/* 家事一覧（無限スクロール対応） */}
       {!isHouseWorksLoading && houseWorksList && (
         <Stack
           direction='row'
@@ -162,6 +188,16 @@ export function HouseWorksTemplate() {
         <Stack alignItems='center' justifyContent='center' padding={4}>
           <CircularProgress />
         </Stack>
+      )}
+      {/* 無限スクロール用センチネル要素 */}
+      {!isHouseWorksLoading && hasNextPage && (
+        <div ref={sentinelRef} style={{ height: '100px' }}>
+          {isLoadingMore && (
+            <Stack alignItems='center' justifyContent='center' padding={2}>
+              <CircularProgress size={32} />
+            </Stack>
+          )}
+        </div>
       )}
       <HouseWorkModal
         open={isModalOpen}

--- a/src/graphql/generated/components.ts
+++ b/src/graphql/generated/components.ts
@@ -350,6 +350,7 @@ export type ListHouseWorksQueryVariables = Exact<{
   familyId: Scalars['ID']['input']
   sort?: InputMaybe<HouseworkSortInput>
   filter?: InputMaybe<HouseworkFilterInput>
+  after?: InputMaybe<Scalars['String']['input']>
 }>
 
 export type ListHouseWorksQuery = {
@@ -481,8 +482,14 @@ export const ListHouseWorksDocument = gql`
     $familyId: ID!
     $sort: HouseworkSortInput
     $filter: HouseworkFilterInput
+    $after: String
   ) {
-    houseworks(familyId: $familyId, sort: $sort, filter: $filter) {
+    houseworks(
+      familyId: $familyId
+      sort: $sort
+      filter: $filter
+      after: $after
+    ) {
       edges {
         cursor
         node {

--- a/src/graphql/generated/components.ts
+++ b/src/graphql/generated/components.ts
@@ -350,6 +350,7 @@ export type ListHouseWorksQueryVariables = Exact<{
   familyId: Scalars['ID']['input']
   sort?: InputMaybe<HouseworkSortInput>
   filter?: InputMaybe<HouseworkFilterInput>
+  first?: InputMaybe<Scalars['Int']['input']>
   after?: InputMaybe<Scalars['String']['input']>
 }>
 
@@ -482,12 +483,14 @@ export const ListHouseWorksDocument = gql`
     $familyId: ID!
     $sort: HouseworkSortInput
     $filter: HouseworkFilterInput
+    $first: Int
     $after: String
   ) {
     houseworks(
       familyId: $familyId
       sort: $sort
       filter: $filter
+      first: $first
       after: $after
     ) {
       edges {

--- a/src/graphql/query/houseworks.graphql
+++ b/src/graphql/query/houseworks.graphql
@@ -2,9 +2,16 @@ query listHouseWorks(
   $familyId: ID!
   $sort: HouseworkSortInput
   $filter: HouseworkFilterInput
+  $first: Int
   $after: String
 ) {
-  houseworks(familyId: $familyId, sort: $sort, filter: $filter, after: $after) {
+  houseworks(
+    familyId: $familyId
+    sort: $sort
+    filter: $filter
+    first: $first
+    after: $after
+  ) {
     edges {
       cursor
       node {

--- a/src/graphql/query/houseworks.graphql
+++ b/src/graphql/query/houseworks.graphql
@@ -2,8 +2,9 @@ query listHouseWorks(
   $familyId: ID!
   $sort: HouseworkSortInput
   $filter: HouseworkFilterInput
+  $after: String
 ) {
-  houseworks(familyId: $familyId, sort: $sort, filter: $filter) {
+  houseworks(familyId: $familyId, sort: $sort, filter: $filter, after: $after) {
     edges {
       cursor
       node {

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -22,6 +22,7 @@ export const useHouseWorks = () => {
       familyId: string,
       sort?: HouseworkSortInput,
       filter?: HouseworkFilterInput,
+      fetchNetworkOnly?: boolean = false,
     ) => {
       setIsLoading(true)
       setEndCursor(null)
@@ -34,6 +35,7 @@ export const useHouseWorks = () => {
             filter: filter,
             first: 10,
           },
+          fetchPolicy: fetchNetworkOnly ? 'network-only' : 'cache-first',
         })
         setHouseWorksList(data?.houseworks)
         setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -69,6 +69,7 @@ export const useHouseWorks = () => {
             first: 10,
             after: endCursor,
           },
+          fetchPolicy: 'network-only',
         })
 
         const newEdges = data?.houseworks?.edges ?? []

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -37,9 +37,18 @@ export const useHouseWorks = () => {
           },
           fetchPolicy: fetchNetworkOnly ? 'network-only' : 'cache-first',
         })
+        const pageInfo = data?.houseworks?.pageInfo
+        console.log(
+          '[getHouseWorksList] Initial fetch - edges:',
+          data?.houseworks?.edges?.length,
+          'hasNextPage:',
+          pageInfo?.hasNextPage,
+          'endCursor:',
+          pageInfo?.endCursor,
+        )
         setHouseWorksList(data?.houseworks)
-        setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)
-        setHasNextPage(data?.houseworks?.pageInfo?.hasNextPage ?? false)
+        setEndCursor(pageInfo?.endCursor ?? null)
+        setHasNextPage(pageInfo?.hasNextPage ?? false)
       } catch (error) {
         console.error('Failed to fetch house works:', error)
       } finally {
@@ -56,11 +65,24 @@ export const useHouseWorks = () => {
       sort?: HouseworkSortInput,
       filter?: HouseworkFilterInput,
     ) => {
-      if (!endCursor || !hasNextPage) return
-      if (isLoadingMore) return
+      console.log(
+        '[loadMoreHouseWorks] Called with endCursor:',
+        endCursor,
+        'hasNextPage:',
+        hasNextPage,
+      )
+
+      if (!endCursor || !hasNextPage) {
+        console.log('[loadMoreHouseWorks] Returning early - no more pages')
+        return
+      }
 
       setIsLoadingMore(true)
       try {
+        console.log(
+          '[loadMoreHouseWorks] Fetching next page with after:',
+          endCursor,
+        )
         const { data } = await listHouseWorks({
           variables: {
             familyId: familyId,
@@ -71,28 +93,44 @@ export const useHouseWorks = () => {
           },
         })
 
+        const newEdges = data?.houseworks?.edges ?? []
+        console.log(
+          '[loadMoreHouseWorks] Fetched',
+          newEdges.length,
+          'new items',
+        )
+
         // 既存データと新規データを統合
         setHouseWorksList((prevList) => {
           if (!prevList) return data?.houseworks
 
-          return {
+          const combined = {
             ...data?.houseworks,
-            edges: [
-              ...(prevList.edges ?? []),
-              ...(data?.houseworks?.edges ?? []),
-            ],
+            edges: [...(prevList.edges ?? []), ...newEdges],
           }
+          console.log(
+            '[loadMoreHouseWorks] Total edges after merge:',
+            combined.edges?.length,
+          )
+          return combined
         })
 
-        setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)
-        setHasNextPage(data?.houseworks?.pageInfo?.hasNextPage ?? false)
+        const newPageInfo = data?.houseworks?.pageInfo
+        setEndCursor(newPageInfo?.endCursor ?? null)
+        setHasNextPage(newPageInfo?.hasNextPage ?? false)
+        console.log(
+          '[loadMoreHouseWorks] Next page info - hasNextPage:',
+          newPageInfo?.hasNextPage,
+          'endCursor:',
+          newPageInfo?.endCursor,
+        )
       } catch (error) {
         console.error('Failed to load more house works:', error)
       } finally {
         setIsLoadingMore(false)
       }
     },
-    [endCursor, hasNextPage, isLoadingMore, listHouseWorks],
+    [endCursor, hasNextPage, listHouseWorks],
   )
 
   return {

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -38,14 +38,6 @@ export const useHouseWorks = () => {
           fetchPolicy: fetchNetworkOnly ? 'network-only' : 'cache-first',
         })
         const pageInfo = data?.houseworks?.pageInfo
-        console.log(
-          '[getHouseWorksList] Initial fetch - edges:',
-          data?.houseworks?.edges?.length,
-          'hasNextPage:',
-          pageInfo?.hasNextPage,
-          'endCursor:',
-          pageInfo?.endCursor,
-        )
         setHouseWorksList(data?.houseworks)
         setEndCursor(pageInfo?.endCursor ?? null)
         setHasNextPage(pageInfo?.hasNextPage ?? false)
@@ -65,24 +57,10 @@ export const useHouseWorks = () => {
       sort?: HouseworkSortInput,
       filter?: HouseworkFilterInput,
     ) => {
-      console.log(
-        '[loadMoreHouseWorks] Called with endCursor:',
-        endCursor,
-        'hasNextPage:',
-        hasNextPage,
-      )
-
-      if (!endCursor || !hasNextPage) {
-        console.log('[loadMoreHouseWorks] Returning early - no more pages')
-        return
-      }
+      if (!endCursor || !hasNextPage) return
 
       setIsLoadingMore(true)
       try {
-        console.log(
-          '[loadMoreHouseWorks] Fetching next page with after:',
-          endCursor,
-        )
         const { data } = await listHouseWorks({
           variables: {
             familyId: familyId,
@@ -94,36 +72,20 @@ export const useHouseWorks = () => {
         })
 
         const newEdges = data?.houseworks?.edges ?? []
-        console.log(
-          '[loadMoreHouseWorks] Fetched',
-          newEdges.length,
-          'new items',
-        )
 
         // 既存データと新規データを統合
         setHouseWorksList((prevList) => {
           if (!prevList) return data?.houseworks
 
-          const combined = {
+          return {
             ...data?.houseworks,
             edges: [...(prevList.edges ?? []), ...newEdges],
           }
-          console.log(
-            '[loadMoreHouseWorks] Total edges after merge:',
-            combined.edges?.length,
-          )
-          return combined
         })
 
         const newPageInfo = data?.houseworks?.pageInfo
         setEndCursor(newPageInfo?.endCursor ?? null)
         setHasNextPage(newPageInfo?.hasNextPage ?? false)
-        console.log(
-          '[loadMoreHouseWorks] Next page info - hasNextPage:',
-          newPageInfo?.hasNextPage,
-          'endCursor:',
-          newPageInfo?.endCursor,
-        )
       } catch (error) {
         console.error('Failed to load more house works:', error)
       } finally {

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -28,7 +28,12 @@ export const useHouseWorks = () => {
       setHasNextPage(false)
       try {
         const { data } = await listHouseWorks({
-          variables: { familyId: familyId, sort: sort, filter: filter },
+          variables: {
+            familyId: familyId,
+            sort: sort,
+            filter: filter,
+            first: 10,
+          },
         })
         setHouseWorksList(data?.houseworks)
         setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)
@@ -59,6 +64,7 @@ export const useHouseWorks = () => {
             familyId: familyId,
             sort: sort,
             filter: filter,
+            first: 10,
             after: endCursor,
           },
         })

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -6,30 +6,93 @@ import {
   ListHouseWorksDocument,
 } from '@/graphql/generated/components'
 import { useLazyQuery } from '@apollo/client'
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 export const useHouseWorks = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false)
   const [houseWorksList, setHouseWorksList] = useState<HouseworkConnection>()
+  const [endCursor, setEndCursor] = useState<string | null>(null)
+  const [hasNextPage, setHasNextPage] = useState<boolean>(false)
   const [listHouseWorks] = useLazyQuery(ListHouseWorksDocument)
 
-  const getHouseWorksList = async (
-    familyId: string,
-    sort?: HouseworkSortInput,
-    filter?: HouseworkFilterInput,
-  ) => {
-    setIsLoading(true)
-    try {
-      const { data } = await listHouseWorks({
-        variables: { familyId: familyId, sort: sort, filter: filter },
-      })
-      setHouseWorksList(data?.houseworks)
-    } catch (error) {
-      console.error('Failed to fetch house works:', error)
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  // 初期データ取得（フィルタやソート変更時に呼び出し）
+  const getHouseWorksList = useCallback(
+    async (
+      familyId: string,
+      sort?: HouseworkSortInput,
+      filter?: HouseworkFilterInput,
+    ) => {
+      setIsLoading(true)
+      setEndCursor(null)
+      setHasNextPage(false)
+      try {
+        const { data } = await listHouseWorks({
+          variables: { familyId: familyId, sort: sort, filter: filter },
+        })
+        setHouseWorksList(data?.houseworks)
+        setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)
+        setHasNextPage(data?.houseworks?.pageInfo?.hasNextPage ?? false)
+      } catch (error) {
+        console.error('Failed to fetch house works:', error)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [listHouseWorks],
+  )
 
-  return { getHouseWorksList, houseWorksList, isLoading }
+  // 次ページのデータを取得（無限スクロール用）
+  const loadMoreHouseWorks = useCallback(
+    async (
+      familyId: string,
+      sort?: HouseworkSortInput,
+      filter?: HouseworkFilterInput,
+    ) => {
+      if (!endCursor || !hasNextPage) return
+      if (isLoadingMore) return
+
+      setIsLoadingMore(true)
+      try {
+        const { data } = await listHouseWorks({
+          variables: {
+            familyId: familyId,
+            sort: sort,
+            filter: filter,
+            after: endCursor,
+          },
+        })
+
+        // 既存データと新規データを統合
+        setHouseWorksList((prevList) => {
+          if (!prevList) return data?.houseworks
+
+          return {
+            ...data?.houseworks,
+            edges: [
+              ...(prevList.edges ?? []),
+              ...(data?.houseworks?.edges ?? []),
+            ],
+          }
+        })
+
+        setEndCursor(data?.houseworks?.pageInfo?.endCursor ?? null)
+        setHasNextPage(data?.houseworks?.pageInfo?.hasNextPage ?? false)
+      } catch (error) {
+        console.error('Failed to load more house works:', error)
+      } finally {
+        setIsLoadingMore(false)
+      }
+    },
+    [endCursor, hasNextPage, isLoadingMore, listHouseWorks],
+  )
+
+  return {
+    getHouseWorksList,
+    loadMoreHouseWorks,
+    houseWorksList,
+    isLoading,
+    isLoadingMore,
+    hasNextPage,
+  }
 }

--- a/src/hooks/api/useHouseWorks.ts
+++ b/src/hooks/api/useHouseWorks.ts
@@ -22,7 +22,7 @@ export const useHouseWorks = () => {
       familyId: string,
       sort?: HouseworkSortInput,
       filter?: HouseworkFilterInput,
-      fetchNetworkOnly?: boolean = false,
+      fetchNetworkOnly: boolean = false,
     ) => {
       setIsLoading(true)
       setEndCursor(null)

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useCurrentUser } from './useCurrentUser'
+export { useIntersectionObserver } from './useIntersectionObserver'
 export { useLocalStorage } from './useLocalStorage'

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useCallback, useRef } from 'react'
 
 /**
  * useIntersectionObserver Hook
@@ -8,45 +8,45 @@ import { useEffect, useRef } from 'react'
  *
  * @param callback - 要素が表示されたときに実行するコールバック関数
  * @param options - IntersectionObserverOptions
- * @returns ref - 監視対象の要素に設定するref
+ * @returns ref - 監視対象の要素に設定するref（Callback ref）
  */
 export const useIntersectionObserver = (
   callback: () => void,
   options?: IntersectionObserverInit,
 ) => {
-  const ref = useRef<HTMLDivElement>(null)
   const callbackRef = useRef(callback)
+  const observerRef = useRef<IntersectionObserver | null>(null)
 
   // コールバックの参照を更新
-  useEffect(() => {
-    callbackRef.current = callback
-  }, [callback])
+  callbackRef.current = callback
 
-  useEffect(() => {
-    if (!ref.current) return
-
-    const observer = new IntersectionObserver(([entry]) => {
-      // デバッグ: Intersection Observer の動作を確認
-      console.log(
-        '[useIntersectionObserver] isIntersecting:',
-        entry.isIntersecting,
-        'ratio:',
-        entry.intersectionRatio,
-      )
-
-      // 要素がビューポートに入ったときにコールバックを実行
-      if (entry.isIntersecting) {
-        console.log('[useIntersectionObserver] Calling callback')
-        callbackRef.current()
+  // Callback ref: DOM ノードが接続・切断されたときに実行される
+  const ref = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!node) {
+        if (observerRef.current) {
+          observerRef.current.disconnect()
+          observerRef.current = null
+        }
+        return
       }
-    }, options)
 
-    observer.observe(ref.current)
+      // 既に observer があれば切断
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+      }
 
-    return () => {
-      observer.disconnect()
-    }
-  }, [options])
+      // 新しい observer を作成
+      observerRef.current = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          callbackRef.current()
+        }
+      }, options)
+
+      observerRef.current.observe(node)
+    },
+    [options],
+  )
 
   return ref
 }

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -23,16 +23,25 @@ export const useIntersectionObserver = (
   }, [callback])
 
   useEffect(() => {
+    if (!ref.current) return
+
     const observer = new IntersectionObserver(([entry]) => {
+      // デバッグ: Intersection Observer の動作を確認
+      console.log(
+        '[useIntersectionObserver] isIntersecting:',
+        entry.isIntersecting,
+        'ratio:',
+        entry.intersectionRatio,
+      )
+
       // 要素がビューポートに入ったときにコールバックを実行
       if (entry.isIntersecting) {
+        console.log('[useIntersectionObserver] Calling callback')
         callbackRef.current()
       }
     }, options)
 
-    if (ref.current) {
-      observer.observe(ref.current)
-    }
+    observer.observe(ref.current)
 
     return () => {
       observer.disconnect()

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,43 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * useIntersectionObserver Hook
+ * 要素がビューポートに入ったときにコールバック関数を実行します
+ *
+ * @param callback - 要素が表示されたときに実行するコールバック関数
+ * @param options - IntersectionObserverOptions
+ * @returns ref - 監視対象の要素に設定するref
+ */
+export const useIntersectionObserver = (
+  callback: () => void,
+  options?: IntersectionObserverInit,
+) => {
+  const ref = useRef<HTMLDivElement>(null)
+  const callbackRef = useRef(callback)
+
+  // コールバックの参照を更新
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      // 要素がビューポートに入ったときにコールバックを実行
+      if (entry.isIntersecting) {
+        callbackRef.current()
+      }
+    }, options)
+
+    if (ref.current) {
+      observer.observe(ref.current)
+    }
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [options])
+
+  return ref
+}


### PR DESCRIPTION
## 概要

家事一覧画面に無限スクロール機能を実装しました。

## 実装内容

### 1. GraphQLクエリの更新
- `$after` パラメータを追加してカーソルベースペーネーション対応
- 既存の pageInfo 構造（hasNextPage、endCursor）を活用

### 2. useIntersectionObserver カスタムフック
**ファイル**: `src/hooks/useIntersectionObserver.ts`

- Intersection Observer API を使用して要素の可視性を検出
- 要素がビューポートに入ったときにコールバック実行
- SSR 環境に対応

### 3. useHouseWorks フック のリファクタリング
**ファイル**: `src/hooks/api/useHouseWorks.ts`

**メソッド追加**:
- `getHouseWorksList`: 初期データ取得（フィルタやソート変更時）
- `loadMoreHouseWorks`: 次ページデータ取得（無限スクロール用）

**状態管理**:
- `isLoadingMore`: 追加データ読み込み中
- `endCursor`: 次ページ取得用カーソル
- `hasNextPage`: 次ページの有無

**特徴**:
- データ累積機能（新規結果を既存リストに追加）
- キャッシュ機能で重複読み込みを防止

### 4. HouseWorksTemplate の更新
**ファイル**: `src/components/templates/HouseWorksTemplate.tsx`

**機能追加**:
- `useIntersectionObserver` を導入
- センチネル要素を画面下部に配置
- スクロール検出時に `loadMoreHouseWorks` を呼び出し
- ローディング中のインジケータ表示
- フィルタ/ソート変更時に自動リセット

## 技術的なポイント

- **Intersection Observer API**: ネイティブブラウザAPI（ライブラリ不要）でシンプル
- **カーソルベースペーネーション**: オフセット方式より動的データセットに適している
- **データ累積**: 新規結果を既存リストに追加（置き換えではない）
- **フィルタ変更時のリセット**: ペーネーションを最初から開始
- **保守性**: GraphQL既存ページネーション機能を有効活用

## テスト計画

- [ ] 初期データ10件の読み込み確認
- [ ] スクロール時に次ページが自動読み込みされることを確認
- [ ] フィルタ変更時にペーネーションがリセットされることを確認
- [ ] ソート変更時に正しく動作することを確認
- [ ] ネットワークエラー時の挙動を確認
- [ ] これ以上データがない場合の表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)