### PR TITLE
家事作成・更新モーダルに削除ボタンを追加する (#30)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,10 @@
       "Bash(yarn format:check)",
       "mcp__mui-mcp__useMuiDocs",
       "Bash(gh pr view:*)",
-      "Bash(gh api:*)"
+      "Bash(gh api:*)",
+      "Bash(gh pr comment:*)",
+      "mcp__inkdrop__read-note",
+      "mcp__inkdrop__update-note"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,9 @@
       "Bash(yarn add zustand)",
       "Bash(find:*)",
       "Bash(yarn format:check)",
-      "mcp__mui-mcp__useMuiDocs"
+      "mcp__mui-mcp__useMuiDocs",
+      "Bash(gh pr view:*)",
+      "Bash(gh api:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/components/organisms/HouseWorkModal.tsx
+++ b/src/components/organisms/HouseWorkModal.tsx
@@ -3,10 +3,12 @@
 import { ToggleButton } from '@/components/atoms'
 import {
   CreateHouseworkDocument,
+  DeleteHouseworkDocument,
   Housework,
   HouseworkCategoryEnum,
   UpdateHouseworkDocument,
 } from '@/graphql/generated/components'
+import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useMutation } from '@apollo/client'
 import { yupResolver } from '@hookform/resolvers/yup'
 import {
@@ -26,7 +28,7 @@ import {
   TextField,
   ToggleButtonGroup,
 } from '@mui/material'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
 import * as yup from 'yup'
@@ -46,6 +48,7 @@ export type HouseWorkModalProps = {
   housework?: Housework | null
   isAdmin: boolean
   onSuccess?: () => void
+  onDelete?: () => void
 }
 
 const schema = yup.object({
@@ -67,8 +70,10 @@ const TOGGLE_BUTTON_STYLE = {
 }
 
 export const HouseWorkModal = (props: HouseWorkModalProps) => {
-  const { open, onClose, housework, isAdmin, onSuccess } = props
+  const { open, onClose, housework, isAdmin, onSuccess, onDelete } = props
   const isEditMode = !!housework
+  const { currentUser } = useCurrentUser()
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
 
   // Form state with react-hook-form
   const {
@@ -95,6 +100,9 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
   )
   const [updateHousework, { loading: updateLoading }] = useMutation(
     UpdateHouseworkDocument,
+  )
+  const [deleteHousework, { loading: deleteLoading }] = useMutation(
+    DeleteHouseworkDocument,
   )
 
   // Initialize form with housework data when editing
@@ -175,6 +183,48 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
   const isUpdateDisabled = isEditMode && !isAdmin && housework?.committed
 
   const loading = createLoading || updateLoading
+
+  // 削除権限の判定
+  const canDelete = (): boolean => {
+    if (!isEditMode || !housework || !currentUser) return false
+
+    const isCreator = currentUser.id === housework.suggestedBy.id
+    const isApproved = housework.committed
+
+    // 未承認の家事：管理者 OR 作成者
+    if (!isApproved) {
+      return isAdmin || isCreator
+    }
+
+    // 承認済みの家事：管理者のみ
+    return isAdmin
+  }
+
+  // 削除処理
+  const handleDelete = async () => {
+    if (!housework) return
+
+    try {
+      const { data: result } = await deleteHousework({
+        variables: {
+          id: housework.id,
+        },
+      })
+
+      if (result?.deleteHousework?.errors.length) {
+        toast.error(`削除エラー: ${result.deleteHousework.errors.join(', ')}`)
+        return
+      }
+
+      toast.success('家事を削除しました')
+      onDelete?.()
+      setDeleteConfirmOpen(false)
+      onClose()
+    } catch (error) {
+      console.error('Failed to delete housework:', error)
+      toast.error('削除処理中にエラーが発生しました')
+    }
+  }
 
   return (
     <Dialog open={open} onClose={onClose} maxWidth='tablet' fullWidth>
@@ -335,7 +385,20 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
             py: 1,
           }}
         >
-          <Box sx={{ flex: 1 }} />
+          {isEditMode && canDelete() && (
+            <Box
+              sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}
+            >
+              <Button
+                onClick={() => setDeleteConfirmOpen(true)}
+                variant='outlined'
+                color='error'
+                disabled={loading || deleteLoading}
+              >
+                削除
+              </Button>
+            </Box>
+          )}
           <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
             <Button
               onClick={handleFormSubmit(handleSubmit)}
@@ -353,6 +416,38 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
           </Box>
         </Box>
       </DialogActions>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={deleteConfirmOpen}
+        onClose={() => setDeleteConfirmOpen(false)}
+      >
+        <DialogTitle>削除確認</DialogTitle>
+        <DialogContent>
+          <Box sx={{ mt: 1 }}>
+            家事「{housework?.title}」を削除してもよろしいですか？
+            <br />
+            この操作は取り消せません。
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button
+            onClick={() => setDeleteConfirmOpen(false)}
+            variant='outlined'
+            disabled={deleteLoading}
+          >
+            キャンセル
+          </Button>
+          <Button
+            onClick={handleDelete}
+            variant='contained'
+            color='error'
+            disabled={deleteLoading}
+          >
+            削除
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Dialog>
   )
 }

--- a/src/components/organisms/HouseWorkModal.tsx
+++ b/src/components/organisms/HouseWorkModal.tsx
@@ -385,10 +385,8 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
             py: 1,
           }}
         >
-          {isEditMode && canDelete() && (
-            <Box
-              sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}
-            >
+          <Box sx={{ flex: 1, display: 'flex', justifyContent: 'flex-start' }}>
+            {isEditMode && canDelete() && (
               <Button
                 onClick={() => setDeleteConfirmOpen(true)}
                 variant='outlined'
@@ -397,8 +395,8 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
               >
                 削除
               </Button>
-            </Box>
-          )}
+            )}
+          </Box>
           <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
             <Button
               onClick={handleFormSubmit(handleSubmit)}

--- a/src/components/templates/HouseWorksTemplate.tsx
+++ b/src/components/templates/HouseWorksTemplate.tsx
@@ -217,6 +217,7 @@ export function HouseWorksTemplate() {
         housework={selectedHousework}
         isAdmin={isAdmin}
         onSuccess={handleModalSuccess}
+        onDelete={handleModalSuccess}
       />
     </Stack>
   )

--- a/src/graphql/generated/components.ts
+++ b/src/graphql/generated/components.ts
@@ -346,6 +346,19 @@ export type UpdateHouseworkMutation = {
   } | null
 }
 
+export type DeleteHouseworkMutationVariables = Exact<{
+  id: Scalars['ID']['input']
+}>
+
+export type DeleteHouseworkMutation = {
+  __typename?: 'Mutation'
+  deleteHousework?: {
+    __typename?: 'DeleteHouseworkMutationPayload'
+    success: boolean
+    errors: Array<string>
+  } | null
+}
+
 export type ListHouseWorksQueryVariables = Exact<{
   familyId: Scalars['ID']['input']
   sort?: InputMaybe<HouseworkSortInput>
@@ -478,6 +491,14 @@ export const UpdateHouseworkDocument = gql`
     }
   }
 `
+export const DeleteHouseworkDocument = gql`
+  mutation deleteHousework($id: ID!) {
+    deleteHousework(input: { id: $id }) {
+      success
+      errors
+    }
+  }
+`
 export const ListHouseWorksDocument = gql`
   query listHouseWorks(
     $familyId: ID!
@@ -591,6 +612,24 @@ export function getSdk(
             signal,
           }),
         'updateHousework',
+        'mutation',
+        variables,
+      )
+    },
+    deleteHousework(
+      variables: DeleteHouseworkMutationVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+      signal?: RequestInit['signal'],
+    ): Promise<DeleteHouseworkMutation> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<DeleteHouseworkMutation>({
+            document: DeleteHouseworkDocument,
+            variables,
+            requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders },
+            signal,
+          }),
+        'deleteHousework',
         'mutation',
         variables,
       )

--- a/src/graphql/query/houseworkMutations.graphql
+++ b/src/graphql/query/houseworkMutations.graphql
@@ -73,3 +73,10 @@ mutation updateHousework(
     errors
   }
 }
+
+mutation deleteHousework($id: ID!) {
+  deleteHousework(input: { id: $id }) {
+    success
+    errors
+  }
+}


### PR DESCRIPTION
## Summary

家事作成・更新モーダルに削除機能を追加しました。削除権限に基づいた権限判定ロジックを実装し、確認ダイアログを表示してから削除処理を実行します。

## Changes

- GraphQL mutation に `deleteHousework` 操作を追加
- HouseWorkModal に削除ボタンと削除確認ダイアログを実装
- 削除権限の判定ロジックを実装
  - **未承認の家事**: 管理者 OR 作成者が削除可能
  - **承認済みの家事**: 管理者のみ削除可能
- 削除処理とエラーハンドリング
- HouseWorksTemplate に onDelete コールバックを追加

## Test plan

- [x] lint: No errors
- [x] format: Code formatted correctly
- [x] tests: All tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)