### PR TITLE
未承認の家事の更新ボタンを作成者以外に無効化 (Issue #31)

### DIFF
--- a/src/components/organisms/HouseWorkModal.tsx
+++ b/src/components/organisms/HouseWorkModal.tsx
@@ -180,7 +180,13 @@ export const HouseWorkModal = (props: HouseWorkModalProps) => {
     }
   }
 
-  const isUpdateDisabled = isEditMode && !isAdmin && housework?.committed
+  const isUpdateDisabled =
+    isEditMode &&
+    ((!isAdmin && housework?.committed) ||
+      (!isAdmin &&
+        !housework?.committed &&
+        currentUser &&
+        currentUser.id !== housework?.suggestedBy.id))
 
   const loading = createLoading || updateLoading
 


### PR DESCRIPTION
## Summary
未承認の家事について、自分が作成した家事でない場合は更新ボタンを押せないようにしました。

## Changes
- isUpdateDisabledロジックを更新して新しい条件を追加
- 承認済みの家事: 管理者以外は更新を無効（既存ルール）
- 未承認の家事: 管理者でなく、かつ自分が作成者でなければ更新を無効（新規ルール）

## Technical Details
- `suggestedBy` カラムでユーザーIDを比較して作成者判定
- `currentUser.id === housework?.suggestedBy.id` で作成者か確認

## Related Issue
closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)