### PR TITLE
feat: HouseWorkCardコンポーネントのUIデザイン調整 (#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@mui/material-nextjs": "^7.1.1",
     "axios": "^1.10.0",
     "axios-hooks": "^5.1.1",
+    "dayjs": "^1.11.18",
     "graphql": "^16.11.0",
     "js-cookie": "^3.0.5",
     "lru-cache": "^11.1.0",

--- a/src/components/organisms/HouseWorkCard.tsx
+++ b/src/components/organisms/HouseWorkCard.tsx
@@ -11,12 +11,50 @@ import {
   Chip,
   Divider,
   Stack,
+  Tooltip,
   Typography,
 } from '@mui/material'
+import dayjs from 'dayjs'
+import ja from 'dayjs/locale/ja'
+import timezone from 'dayjs/plugin/timezone'
+import utc from 'dayjs/plugin/utc'
+
+// Setup dayjs
+dayjs.extend(utc)
+dayjs.extend(timezone)
+dayjs.locale(ja)
 
 export type HouseWorkCardProps = CardProps & {
   housework: Housework
   onClick?: () => void
+}
+
+/**
+ * Format date to Japan timezone (YYYY/MM/DD HH:MM:SS)
+ */
+const formatDateToJST = (dateString: string): string => {
+  return dayjs(dateString).tz('Asia/Tokyo').format('YYYY/MM/DD HH:mm:ss')
+}
+
+/**
+ * Check if text is truncated and return truncated text with ellipsis
+ */
+const truncateText = (
+  text: string,
+  maxLines: number,
+  maxCharPerLine: number,
+): { truncated: string; isTruncated: boolean } => {
+  const maxChars = maxLines * maxCharPerLine
+  if (text.length > maxChars) {
+    return {
+      truncated: text.substring(0, maxChars - 1) + '...',
+      isTruncated: true,
+    }
+  }
+  return {
+    truncated: text,
+    isTruncated: false,
+  }
 }
 
 /**
@@ -53,6 +91,19 @@ const getLabel = (housework: Housework): string | null => {
 export const HouseWorkCard = (props: HouseWorkCardProps) => {
   const { housework, onClick, ...remainProps } = props
   const label = getLabel(housework)
+
+  // Text truncation for title (1 line, ~25 chars)
+  const titleTruncation = truncateText(housework.title, 1, 25)
+
+  // Text truncation for description (2 lines, ~20 chars per line)
+  const descriptionTruncation = truncateText(housework.description || '', 2, 20)
+
+  // Text truncation for schedule (2 lines, ~20 chars per line)
+  const scheduleTruncation = truncateText(housework.schedule || '', 2, 20)
+
+  // Format dates to JST
+  const formattedCreatedAt = formatDateToJST(housework.createdAt)
+  const formattedUpdatedAt = formatDateToJST(housework.updatedAt)
 
   return (
     <Card
@@ -95,7 +146,22 @@ export const HouseWorkCard = (props: HouseWorkCardProps) => {
               justifyContent='space-between'
               alignItems='center'
             >
-              <Typography variant='h2'>{housework.title}</Typography>
+              <Tooltip
+                title={housework.title}
+                disableHoverListener={!titleTruncation.isTruncated}
+              >
+                <Typography
+                  variant='h2'
+                  sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    flex: 1,
+                  }}
+                >
+                  {titleTruncation.truncated}
+                </Typography>
+              </Tooltip>
               <Box
                 p={0.5}
                 sx={{ backgroundColor: '#C5ECA3', borderRadius: '6px' }}
@@ -103,15 +169,62 @@ export const HouseWorkCard = (props: HouseWorkCardProps) => {
                 <Typography variant='h4'>{housework.point}p</Typography>
               </Box>
             </Stack>
-            <Typography variant='h4'>{housework.description}</Typography>
+            <Tooltip
+              title={housework.description || ''}
+              disableHoverListener={!descriptionTruncation.isTruncated}
+            >
+              <Typography
+                variant='h4'
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  minHeight: '2.4em',
+                }}
+              >
+                {descriptionTruncation.truncated}
+              </Typography>
+            </Tooltip>
             <Divider />
-            <Typography variant='body1'>{housework.schedule}</Typography>
+            <Tooltip
+              title={housework.schedule || ''}
+              disableHoverListener={!scheduleTruncation.isTruncated}
+            >
+              <Typography
+                variant='body1'
+                sx={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  minHeight: '2.4em',
+                }}
+              >
+                {scheduleTruncation.truncated}
+              </Typography>
+            </Tooltip>
             <Divider />
-            <Typography variant='h4'>
-              Suggested {housework.suggestedBy.name}
-            </Typography>
-            <Typography variant='h4'>Created {housework.createdAt}</Typography>
-            <Typography variant='h4'>Updated {housework.updatedAt}</Typography>
+            <Stack direction='row' spacing={1}>
+              <Typography variant='h4' sx={{ width: '80px', flexShrink: 0 }}>
+                Suggested
+              </Typography>
+              <Typography variant='h4'>{housework.suggestedBy.name}</Typography>
+            </Stack>
+            <Stack direction='row' spacing={1}>
+              <Typography variant='h4' sx={{ width: '80px', flexShrink: 0 }}>
+                Created
+              </Typography>
+              <Typography variant='h4'>{formattedCreatedAt}</Typography>
+            </Stack>
+            <Stack direction='row' spacing={1}>
+              <Typography variant='h4' sx={{ width: '80px', flexShrink: 0 }}>
+                Updated
+              </Typography>
+              <Typography variant='h4'>{formattedUpdatedAt}</Typography>
+            </Stack>
           </Stack>
         </CardContent>
       </CardActionArea>

--- a/src/components/organisms/HouseWorkCard.tsx
+++ b/src/components/organisms/HouseWorkCard.tsx
@@ -108,7 +108,7 @@ export const HouseWorkCard = (props: HouseWorkCardProps) => {
   return (
     <Card
       sx={{
-        width: '250px',
+        width: '260px',
         boxShadow: '0px 4px 4px 0px rgb(0 0 0 / 20%)',
         position: 'relative',
       }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3707,6 +3707,11 @@ dataloader@^2.2.3:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.3.tgz#42d10b4913515f5b37c6acedcb4960d6ae1b1517"
   integrity sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==
 
+dayjs@^1.11.18:
+  version "1.11.18"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.18.tgz#835fa712aac52ab9dec8b1494098774ed7070a11"
+  integrity sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==
+
 debounce@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"


### PR DESCRIPTION
## 概要
HouseWorkCardコンポーネントのUIをデザイン調整しました。

## 実装内容

### 1. 日時フォーマット
- 作成日時（Created）、更新日時（Updated）をJST（日本時間）で表示
- フォーマット: YYYY/MM/DD HH:MM:SS

### 2. テキスト表示の制限
- title、description、scheduleの表示部分で文字が長く表示しきれない場合は末尾を「...」にする（テキストトランケーション）
- description、scheduleは2行に固定

### 3. Tooltip機能
- title、description、scheduleが表示しきれていない場合、マウスオーバー時にtooltipで完全なテキストを表示
- `disableHoverListener`を使用して、テキストが完全に表示される場合はtooltipを表示しない

### 4. ラベルとデータの配置
- Suggested、Created、Updatedの項目について、ラベル幅を固定（80px）して統一
- データ部分の左端を3項目で揃えるように配置
- Stack の `direction='row'` と `spacing={1}` を使用して見た目を整える

## 技術詳細
- **dayjs** (v1.11.18) を新規追加
  - timezone、utcプラグインでJSTタイムゾーン対応
  - 日本語ロケール対応

- **テキストトランケーション実装**
  - CSS `text-overflow: ellipsis` とWebKit extensions (`-webkit-box`, `WebkitLineClamp`) を使用
  - `minHeight` を設定して行の高さを確保

- **Tooltip機能**
  - MUI Tooltipコンポーネントを活用
  - テキストの長さに基づいて自動的にtooltip表示を制御

## テスト結果
- ✅ 全テスト成功
- ✅ Lint チェック成功
- ✅ Format チェック成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)